### PR TITLE
Update defsystem for recent ASDF versions

### DIFF
--- a/cl-template.asd
+++ b/cl-template.asd
@@ -3,12 +3,12 @@
   :version "0.0.1"
   :author "Peter Cannici <turkchess123@gmail.com>"
   :license "MIT"
-  :in-order-to ((test-op (test-op #:cl-template-tests)))
+  :in-order-to ((test-op (test-op #:cl-template/tests)))
   :components ((:file "packages")
                (:file "util" :depends-on ("packages"))
                (:file "cl-template" :depends-on ("packages" "util"))))
 
-(asdf:defsystem #:cl-template-tests
+(asdf:defsystem #:cl-template/tests
   :description "Unit tests for cl-template."
   :version "0.0.1"
   :author "Peter Cannici <turkchess123@gmail.com>"


### PR DESCRIPTION
Having multiple systems declared in a singe asd file is deprecated, and ASDF now requires that any subsystems be namespaced with a `/`.

This is shown by a message when loading the system with recent versions of ASDF
```
WARNING: System definition file #P"/home/rsim/.roswell/lisp/quicklisp/dists/quicklisp/software/cl-template-20130615-git/cl-template.asd" contains definition for system "cl-template-tests". Please only define "cl-template" and secondary systems with a name starting with "cl-template/" (e.g. "cl-template/test") in that file.
```